### PR TITLE
(fix):Stop image disappear over and over ref #253080

### DIFF
--- a/src/components/Blocks/Hero/Hero.jsx
+++ b/src/components/Blocks/Hero/Hero.jsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { isInternalURL } from '@plone/volto/helpers/Url/Url';
 import { isImageGif } from '@eeacms/volto-hero-block/helpers';
-import { useOnScreen } from '@eeacms/volto-hero-block/hooks';
+import { useFirstVisited } from '@eeacms/volto-hero-block/hooks';
 
 Hero.propTypes = {
   image: PropTypes.string,
@@ -33,7 +33,7 @@ function Hero({
     styles || {};
 
   const bgImgRef = React.useRef();
-  const onScreen = useOnScreen(bgImgRef);
+  const onScreen = useFirstVisited(bgImgRef);
   return (
     <div
       className={cx(

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,17 +1,12 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React from 'react';
 
-function useOnScreen(ref, rootMargin = '0px') {
-  const [isIntersecting, setIntersecting] = React.useState(false);
-  const [mounted, setMounted] = React.useState(false);
-
+function useFirstVisited(ref, rootMargin = '0px') {
+  const [intersected, setIntersected] = React.useState(false);
   React.useEffect(() => {
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (mounted === false) {
-          setIntersecting(entry.isIntersecting);
-          if (entry.isIntersecting === true) setMounted(true);
-        }
+        setIntersected(intersected === false ? entry.isIntersecting : true);
       },
       {
         rootMargin,
@@ -28,8 +23,8 @@ function useOnScreen(ref, rootMargin = '0px') {
       }
       observer.disconnect();
     };
-  }, [ref, rootMargin, mounted]);
-  return isIntersecting;
+  }, [ref, rootMargin, intersected]);
+  return intersected;
 }
 
-export { useOnScreen };
+export { useFirstVisited };

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -4,6 +4,7 @@ import React from 'react';
 function useFirstVisited(ref, rootMargin = '0px') {
   const [intersected, setIntersected] = React.useState(false);
   React.useEffect(() => {
+    if (intersected) return;
     const observer = new IntersectionObserver(
       ([entry]) => {
         setIntersected(intersected === false ? entry.isIntersecting : true);

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -3,11 +3,15 @@ import React from 'react';
 
 function useOnScreen(ref, rootMargin = '0px') {
   const [isIntersecting, setIntersecting] = React.useState(false);
+  const [mounted, setMounted] = React.useState(false);
 
   React.useEffect(() => {
     const observer = new IntersectionObserver(
       ([entry]) => {
-        setIntersecting(entry.isIntersecting);
+        if (mounted === false) {
+          setIntersecting(entry.isIntersecting);
+          if (entry.isIntersecting === true) setMounted(true);
+        }
       },
       {
         rootMargin,
@@ -24,7 +28,7 @@ function useOnScreen(ref, rootMargin = '0px') {
       }
       observer.disconnect();
     };
-  }, [ref, rootMargin]);
+  }, [ref, rootMargin, mounted]);
   return isIntersecting;
 }
 


### PR DESCRIPTION
I fixed:  the hero block background images should remain when the element enters for the first time in the viewport
